### PR TITLE
Load auth routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -107,3 +107,5 @@ Route::middleware($authVerified)->group(function () {
 
 // Perfil público por ID/binding
 Route::get('/u/{user}', [ProfileController::class, 'show'])->whereNumber('user')->name('profile.show');
+
+require __DIR__ . '/auth.php';


### PR DESCRIPTION
## Summary
- require the auth route definitions so login and related endpoints are registered

## Testing
- php artisan test *(fails: vendor/autoload.php missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e42f989d14832c96c5a98087ddceac