### PR TITLE
Handle attendance locking without FOR UPDATE support

### DIFF
--- a/app/Http/Controllers/MesaHonorController.php
+++ b/app/Http/Controllers/MesaHonorController.php
@@ -7,6 +7,7 @@ use App\Models\GameTable;
 use App\Models\Signup;
 use App\Models\User;
 use App\Services\HonorRules;
+use App\Support\DatabaseUtils;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -36,7 +37,9 @@ class MesaHonorController extends Controller
         DB::transaction(function () use ($signup, $auth) {
             // Releer con lock para evitar carreras
             /** @var Signup $row */
-            $row = Signup::query()->whereKey($signup->id)->lockForUpdate()->firstOrFail();
+            $row = DatabaseUtils::applyPessimisticLock(
+                Signup::query()->whereKey($signup->id)
+            )->firstOrFail();
 
             if (!$row->attendance_confirmed_at) {
                 $row->attendance_confirmed_at = now();
@@ -70,7 +73,9 @@ class MesaHonorController extends Controller
 
         DB::transaction(function () use ($signup, $auth) {
             /** @var Signup $row */
-            $row = Signup::query()->whereKey($signup->id)->lockForUpdate()->firstOrFail();
+            $row = DatabaseUtils::applyPessimisticLock(
+                Signup::query()->whereKey($signup->id)
+            )->firstOrFail();
 
             if (!$row->no_show_at) {
                 $row->no_show_at = now();

--- a/app/Support/DatabaseUtils.php
+++ b/app/Support/DatabaseUtils.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Utilidades para manejar conexiones de base de datos en entornos compartidos.
+ */
+final class DatabaseUtils
+{
+    /** Drivers que no soportan SELECT ... FOR UPDATE. */
+    private const LOCK_UNSUPPORTED_DRIVERS = ['sqlite', 'sqlsrv'];
+
+    private function __construct()
+    {
+        // static class
+    }
+
+    /** Determina si la conexión soporta bloqueos pesimistas. */
+    public static function supportsPessimisticLock(?ConnectionInterface $connection = null): bool
+    {
+        $connection ??= DB::connection();
+
+        $driver = $connection->getDriverName();
+
+        return !in_array($driver, self::LOCK_UNSUPPORTED_DRIVERS, true);
+    }
+
+    /**
+     * Aplica lockForUpdate sólo si la conexión lo soporta.
+     *
+     * @template TModel of \Illuminate\Database\Eloquent\Model
+     * @param Builder<TModel> $query
+     * @return Builder<TModel>
+     */
+    public static function applyPessimisticLock(Builder $query): Builder
+    {
+        $connection = $query->getModel()->getConnection();
+
+        if (self::supportsPessimisticLock($connection)) {
+            $query->lockForUpdate();
+        }
+
+        return $query;
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared DatabaseUtils helper to detect drivers that cannot handle `SELECT ... FOR UPDATE`
- update attendance and honor controllers to rely on conditional pessimistic locking so sqlite/shared hosts avoid 500 errors
- harden honor point inserts by tolerating duplicate-key races when two requests confirm the same action

## Testing
- php -l app/Support/DatabaseUtils.php
- php -l app/Http/Controllers/AttendanceController.php
- php -l app/Http/Controllers/MesaHonorController.php
- php -l app/Models/Concerns/HasHonor.php
- composer install *(fails: GitHub API rate limit / requires token)*

------
https://chatgpt.com/codex/tasks/task_e_68e43f317af8832c9826363db7adf924