### PR TITLE
Fix mesa voting forms to use signup routes

### DIFF
--- a/resources/views/tables/_card.blade.php
+++ b/resources/views/tables/_card.blade.php
@@ -79,15 +79,15 @@
             @auth
                 @if($isOpenNow)
                     @if($alreadyThis)
-                        @if (Route::has('mesas.unvote'))
-                            <form method="POST" action="{{ route('mesas.unvote', $mesa) }}">
+                        @if (Route::has('signups.destroy'))
+                            <form method="POST" action="{{ route('signups.destroy', $mesa) }}">
                                 @csrf @method('DELETE')
                                 <button class="btn danger block" type="submit">{{ $label }}</button>
                             </form>
                         @endif
                     @else
-                        @if (Route::has('mesas.vote'))
-                            <form method="POST" action="{{ route('mesas.vote', $mesa) }}">
+                        @if (Route::has('signups.store'))
+                            <form method="POST" action="{{ route('signups.store', $mesa) }}">
                                 @csrf
                                 @if($signedOther)<input type="hidden" name="switch" value="1">@endif
                                 <button class="btn ok block" type="submit"
@@ -104,8 +104,8 @@
                         @endif
                     @endif
                 @elseif(($mesa->is_open ?? false) && $opensTs > time())
-                    @if (Route::has('mesas.vote'))
-                        <form method="POST" action="{{ route('mesas.vote', $mesa) }}">
+                    @if (Route::has('signups.store'))
+                        <form method="POST" action="{{ route('signups.store', $mesa) }}">
                             @csrf
                             <button class="btn ok block js-enable-at" type="submit"
                                 disabled data-enable-at="{{ $opensTs }}" aria-describedby="hint-{{ $mesa->id }}"

--- a/resources/views/tables/show.blade.php
+++ b/resources/views/tables/show.blade.php
@@ -207,8 +207,8 @@
         $state = $isOpenNow ? 1 : 0;
         $logicalRev = "{$revTs}:{$state}:{$opensTs}";
 
-        $canVoteRoute = \Illuminate\Support\Facades\Route::has('mesas.vote');
-        $canUnvoteRoute = \Illuminate\Support\Facades\Route::has('mesas.unvote');
+        $canVoteRoute = \Illuminate\Support\Facades\Route::has('signups.store');
+        $canUnvoteRoute = \Illuminate\Support\Facades\Route::has('signups.destroy');
         $canOpenRoute = \Illuminate\Support\Facades\Route::has('mesas.open');
         $canCloseRoute = \Illuminate\Support\Facades\Route::has('mesas.close');
         $canEditRoute = \Illuminate\Support\Facades\Route::has('mesas.edit');
@@ -587,7 +587,7 @@
                         @if(!$alreadySigned)
                             @if ($canVoteRoute)
                                 <form method="POST"
-                                      action="{{ route('mesas.vote', $mesa) }}">
+                                      action="{{ route('signups.store', $mesa) }}">
                                     @csrf
                                     <button class="btn ok"
                                             style="width:100%"
@@ -609,7 +609,7 @@
                         @else
                             @if ($canUnvoteRoute)
                                 <form method="POST"
-                                      action="{{ route('mesas.unvote', $mesa) }}">
+                                      action="{{ route('signups.destroy', $mesa) }}">
                                     @csrf
                                     @method('DELETE')
                                     <button class="btn danger"


### PR DESCRIPTION
## Summary
- update mesa card and detail views to reference the new signups routes for voting actions
- keep route availability checks in sync so the vote button renders when the signup routes exist

## Testing
- not run (composer install requires GitHub token)


------
https://chatgpt.com/codex/tasks/task_e_68e44160edb4832ca8f3120aa971dc57