### PR TITLE
Fix API ETag comparison and guard pessimistic locks

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -193,6 +193,6 @@ class ApiController extends Controller
     private function etagEqualsWeak(string $a, string $b): bool
     {
         $norm = static fn(string $t) => trim(str_ireplace('W/', '', $t), " \t\n\r\0\x0B\"");
-        return $norm($a) !== '' && $norm($a) === $norm(b: $b);
+        return $norm($a) !== '' && $norm($a) === $norm($b);
     }
 }

--- a/app/Http/Controllers/GameTableAdminController.php
+++ b/app/Http/Controllers/GameTableAdminController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Events\GameTableClosed;
 use App\Models\GameTable;
+use App\Support\DatabaseUtils;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -31,8 +32,7 @@ class GameTableAdminController extends Controller
         try {
             $closed = DB::transaction(function () use ($mesa): bool {
                 /** @var GameTable $row */
-                $row = GameTable::query()
-                    ->lockForUpdate()
+                $row = DatabaseUtils::applyPessimisticLock(GameTable::query())
                     ->findOrFail($mesa->getKey());
 
                 // Preferir métodos de dominio si existen

--- a/tests/Unit/ApiControllerTest.php
+++ b/tests/Unit/ApiControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Http\Controllers\ApiController;
+use ReflectionClass;
+use Tests\TestCase;
+
+final class ApiControllerTest extends TestCase
+{
+    public function testEtagEqualsWeakIgnoresWeakPrefixAndQuotes(): void
+    {
+        $controller = new class extends ApiController
+        {
+            public function etagEqualsWeakProxy(string $a, string $b): bool
+            {
+                $reflection = new ReflectionClass(ApiController::class);
+                $method = $reflection->getMethod('etagEqualsWeak');
+                $method->setAccessible(true);
+
+                return (bool) $method->invoke($this, $a, $b);
+            }
+        };
+
+        $this->assertTrue($controller->etagEqualsWeakProxy('W/"abc"', '"abc"'));
+        $this->assertTrue($controller->etagEqualsWeakProxy('"abc"', 'W/"abc"'));
+        $this->assertFalse($controller->etagEqualsWeakProxy('"abc"', '"def"'));
+        $this->assertFalse($controller->etagEqualsWeakProxy('""', '"abc"'));
+    }
+}

--- a/tests/Unit/DatabaseUtilsTest.php
+++ b/tests/Unit/DatabaseUtilsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Support\DatabaseUtils;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class DatabaseUtilsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('dummy_records');
+
+        Schema::create('dummy_records', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+        });
+
+        DummyRecord::query()->create(['name' => 'demo']);
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('dummy_records');
+
+        parent::tearDown();
+    }
+
+    public function testSupportsPessimisticLockIsFalseForSqlite(): void
+    {
+        $this->assertFalse(DatabaseUtils::supportsPessimisticLock());
+    }
+
+    public function testApplyPessimisticLockDoesNotBreakOnSqlite(): void
+    {
+        $record = DatabaseUtils::applyPessimisticLock(DummyRecord::query())->first();
+
+        $this->assertNotNull($record);
+        $this->assertSame('demo', $record->name);
+    }
+}
+
+/**
+ * @extends Model<array<string, mixed>>
+ */
+final class DummyRecord extends Model
+{
+    protected $table = 'dummy_records';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+}


### PR DESCRIPTION
## Summary
- fix the weak ETag comparison in ApiController to avoid invalid named parameter usage
- rely on DatabaseUtils::applyPessimisticLock when closing tables and managing signups so sqlite can run without FOR UPDATE support
- cover the helper changes with new unit tests for DatabaseUtils and ApiController

## Testing
- php -l app/Http/Controllers/ApiController.php
- php -l app/Http/Controllers/GameTableAdminController.php
- php -l app/Http/Controllers/SignupController.php
- php -l tests/Unit/ApiControllerTest.php
- php -l tests/Unit/DatabaseUtilsTest.php
- composer install *(fails: CONNECT tunnel 403 when downloading from GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_68e47f986e6c832ca4dc3aaa62aebffd