### PR TITLE
Mejoras en home y gestión de mesas

### DIFF
--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -22,6 +22,14 @@ class AttendanceController extends Controller
         $user = $request->user();
         abort_unless($user, 403);
 
+        // Normalizamos selects con valor "sin cambios" antes de validar.
+        if ($request->input('attended') === '_keep_') {
+            $request->request->remove('attended');
+        }
+        if ($request->input('behavior') === '_keep_') {
+            $request->request->remove('behavior');
+        }
+
         $isOwner = (int) ($mesa->created_by ?? 0) === (int) $user->id;
         $isManager = (int) ($mesa->manager_id ?? 0) === (int) $user->id;
         $isAdmin = (string) ($user->role ?? '') === 'admin';

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -13,13 +13,26 @@
 .home-wrap{max-width:960px;margin-inline:auto;padding:1rem}
 .card-pad{padding:1rem}
 .section{margin-top:1rem}
-.home-hero{display:flex;flex-direction:column;gap:.75rem}
+.home-hero{display:grid;gap:1.5rem;grid-template-columns:minmax(0,1fr) minmax(0,320px);align-items:flex-start}
+.home-hero-main{display:flex;flex-direction:column;gap:1rem}
 .home-title{margin:.2rem 0;color:var(--maroon);line-height:1.15}
 .home-sub{margin:0;color:var(--muted)}
 .link{color:var(--maroon);text-decoration:none}
 .link:hover{text-decoration:underline}
 .home-actions{display:flex;gap:.6rem;flex-wrap:wrap}
-.home-divider{height:1px;background:var(--border);margin:.5rem 0 1rem}
+.home-benefits{list-style:none;margin:0;padding:0;display:grid;gap:.6rem}
+.home-benefits li{display:flex;gap:.5rem;align-items:flex-start;color:var(--muted)}
+.home-benefits li span:first-child{font-size:1.2rem;line-height:1.5}
+.home-benefits strong{color:var(--maroon)}
+.home-hero-aside{padding:1rem;border:1px dashed var(--border);border-radius:.75rem;display:flex;flex-direction:column;gap:.75rem;background:rgba(123,45,38,.03)}
+.home-hero-aside h2{margin:0;color:var(--maroon)}
+.home-hero-aside ul{list-style:none;margin:0;padding:0;display:grid;gap:.5rem;color:var(--muted);font-size:.95rem}
+.home-hero-aside li{display:flex;gap:.4rem;align-items:flex-start}
+.home-hero-aside .emoji{font-size:1.1rem;line-height:1.4}
+.home-tips{display:grid;gap:1rem;margin-top:1rem;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+.home-tip{padding:1rem;border:1px solid var(--border);border-radius:.75rem;display:flex;flex-direction:column;gap:.5rem;background:var(--card,#fff)}
+.home-tip h3{margin:0;color:var(--maroon)}
+.home-tip p{margin:0;color:var(--muted);font-size:.95rem}
 
 .mesa-card{display:flex;gap:1rem;align-items:flex-start}
 .mesa-thumb{flex:0 0 160px;border-radius:.6rem;overflow:hidden;border:1px solid var(--border);background:#f8f9fa}
@@ -55,6 +68,10 @@
   .mesa-thumb img{height:180px}
 }
 
+@media (max-width:860px){
+  .home-hero{grid-template-columns:1fr}
+}
+
 @media (prefers-color-scheme: dark){
   :root{--border:#2d2f33; --muted:#a7b0ba}
   .home-divider{background:#2d2f33}
@@ -70,14 +87,20 @@
 
 @section('content')
 <main class="home-wrap" aria-labelledby="home-title">
+  @php $myMesaContext = $myMesaContext ?? []; @endphp
   {{-- HERO --}}
-  <section class="card home-hero card-pad">
-    <h1 id="home-title" class="home-title">Bienvenid@ a {{ config('app.name', 'La Taberna') }}</h1>
-    <p class="home-sub">Organizá partidas, descubrí mesas abiertas y sumate a la comunidad.</p>
+  <section class="card card-pad home-hero">
+    <div class="home-hero-main">
+      <h1 id="home-title" class="home-title">Bienvenid@ a {{ config('app.name', 'La Taberna') }}</h1>
+      <p class="home-sub">Organizá partidas, descubrí mesas abiertas y sumate a la comunidad.</p>
 
-    <div class="home-divider" role="separator" aria-hidden="true"></div>
+      <ul class="home-benefits">
+        <li><span>🎲</span> <span>{{ __('Armá mesas y administrá inscripciones sin planillas externas.') }}</span></li>
+        <li><span>📝</span> <span>{{ __('Compartí notas privadas con tus jugadores y dejá todo documentado.') }}</span></li>
+        <li><span>🏅</span> <span>{{ __('Seguimiento de asistencia y honor automatizado para cada jugador.') }}</span></li>
+      </ul>
 
-    @php
+      @php
       $mesasIndexUrl  = \Illuminate\Support\Facades\Route::has('mesas.index')  ? route('mesas.index')  : url('/mesas');
       $mesasCreateUrl = \Illuminate\Support\Facades\Route::has('mesas.create') ? route('mesas.create') : url('/mesas/create');
       $panelUrl       = \Illuminate\Support\Facades\Route::has('dashboard')    ? route('dashboard')    : url('/panel');
@@ -85,26 +108,34 @@
       $registerUrl    = \Illuminate\Support\Facades\Route::has('register')     ? route('register')     : url('/register');
     @endphp
 
-    <nav class="home-actions" aria-label="Acciones principales">
-      @auth
-        {{-- Ir a mi mesa (si no hay, el controlador redirige) --}}
-        @if(\Illuminate\Support\Facades\Route::has('mesas.mine'))
-          <a class="btn" href="{{ route('mesas.mine') }}" aria-label="Ir a mi mesa">Ir a mi mesa</a>
+      <nav class="home-actions" aria-label="Acciones principales">
+        @auth
+          <a class="btn" href="{{ $mesasIndexUrl }}">{{ __('Mis mesas') }}</a>
+
+          {{-- Mostrar "Crear mesa" según policy (GameTablePolicy@create) --}}
+          @can('create', \App\Models\GameTable::class)
+            <a class="btn gold" href="{{ $mesasCreateUrl }}">➕ {{ __('Crear mesa') }}</a>
+          @endcan
+
+          <a class="btn" href="{{ $panelUrl }}">{{ __('Ir a mi panel') }}</a>
         @else
-          <a class="btn" href="{{ $mesasIndexUrl }}">Mis mesas</a>
+          <a class="btn" href="{{ $registerUrl }}">{{ __('Crear cuenta') }}</a>
+          <a class="btn" href="{{ $loginUrl }}">{{ __('Entrar') }}</a>
+        @endauth
+      </nav>
+    </div>
+
+    <aside class="home-hero-aside">
+      <h2>{{ __('Todo lo importante en un solo lugar') }}</h2>
+      <ul>
+        <li><span class="emoji">✅</span> <span>{{ __('Confirmá asistencia y comportamiento con un clic por jugador.') }}</span></li>
+        <li><span class="emoji">🔐</span> <span>{{ __('Notas visibles solo para inscriptos y encargados.') }}</span></li>
+        <li><span class="emoji">📈</span> <span>{{ __('Seguimiento de honor y estadísticas al día.') }}</span></li>
+        @if(($myMesaContext['canSeeNotes'] ?? false) && !empty($myMesaContext['notesUrl']))
+          <li><span class="emoji">🗒️</span> <span><a class="link" href="{{ $myMesaContext['notesUrl'] }}">{{ __('Acceder a las notas de mi mesa') }}</a></span></li>
         @endif
-
-        {{-- Mostrar "Crear mesa" según policy (GameTablePolicy@create) --}}
-        @can('create', \App\Models\GameTable::class)
-          <a class="btn gold" href="{{ $mesasCreateUrl }}">➕ Crear mesa</a>
-        @endcan
-
-        <a class="btn" href="{{ $panelUrl }}">Ir a mi panel</a>
-      @else
-        <a class="btn" href="{{ $registerUrl }}">Crear cuenta</a>
-        <a class="btn" href="{{ $loginUrl }}">Entrar</a>
-      @endauth
-    </nav>
+      </ul>
+    </aside>
   </section>
 
   {{-- Tu mesa actual (si existe) --}}
@@ -197,6 +228,9 @@
 
               <div class="mesa-actions">
                 <a class="btn" href="{{ $mesaShowUrl }}">Ver mesa</a>
+                @if(($myMesaContext['canSeeNotes'] ?? false) && !empty($myMesaContext['notesUrl']))
+                  <a class="btn" href="{{ $myMesaContext['notesUrl'] }}">Notas de la mesa</a>
+                @endif
                 <a class="btn" href="{{ $mesaShowUrl }}#jugadores">Ver jugadores</a>
                 <a class="btn" href="{{ $mesasIndexUrl }}">Explorar otras</a>
               </div>
@@ -267,6 +301,24 @@
         </div>
       @endif
     @endif
+  </section>
+
+  <section class="card card-pad section">
+    <h2 style="margin-top:0;color:var(--maroon)">{{ __('Herramientas para encargados') }}</h2>
+    <div class="home-tips">
+      <article class="home-tip">
+        <h3>🗒️ {{ __('Notas compartidas') }}</h3>
+        <p>{{ __('Guardá recordatorios, consignas o enlaces especiales y compartilos solo con tu mesa.') }}</p>
+      </article>
+      <article class="home-tip">
+        <h3>👥 {{ __('Control de asistencia') }}</h3>
+        <p>{{ __('Confirmá asistencia o marcá ausencias sin salir de la plataforma y sumá honor automáticamente.') }}</p>
+      </article>
+      <article class="home-tip">
+        <h3>🧙 {{ __('Encargado siempre presente') }}</h3>
+        <p>{{ __('Figurás como jugador por defecto y podés liberar tu lugar con un solo clic si preferís dirigir.') }}</p>
+      </article>
+    </div>
   </section>
 
   {{-- DEBUG (solo con APP_DEBUG=true) --}}

--- a/resources/views/tables/create.blade.php
+++ b/resources/views/tables/create.blade.php
@@ -164,24 +164,6 @@
                 </datalist>
             </div>
 
-            {{-- Encargado cuenta como jugador --}}
-            <div>
-                <input type="hidden"
-                       name="manager_counts_as_player"
-                       value="0">
-                <label for="manager_counts_as_player"
-                       style="display:flex;gap:.5rem;align-items:center">
-                    <input id="manager_counts_as_player"
-                           type="checkbox"
-                           name="manager_counts_as_player"
-                           value="1"
-                           {{ old('manager_counts_as_player', 1) ? 'checked' : '' }}>
-                    <span>{{ __('El encargado ocupa un lugar de jugador') }}</span>
-                </label>
-                <small class="muted">{{ __('Desmarcá si querés que el encargado quede fuera del conteo de asientos disponibles.') }}</small>
-                @error('manager_counts_as_player') <div class="text-danger">{{ $message }}</div> @enderror
-            </div>
-
             {{-- Nota privada para el encargado --}}
             <div style="grid-column:1/-1">
                 <label for="manager_note">{{ __('Nota interna para el encargado (opcional)') }}</label>

--- a/resources/views/tables/edit.blade.php
+++ b/resources/views/tables/edit.blade.php
@@ -147,24 +147,6 @@
                 </datalist>
             </div>
 
-            {{-- Encargado cuenta como jugador --}}
-            <div>
-                <input type="hidden"
-                       name="manager_counts_as_player"
-                       value="0">
-                <label for="manager_counts_as_player"
-                       style="display:flex;gap:.5rem;align-items:center">
-                    <input id="manager_counts_as_player"
-                           type="checkbox"
-                           name="manager_counts_as_player"
-                           value="1"
-                           {{ old('manager_counts_as_player', $mesa->manager_counts_as_player) ? 'checked' : '' }}>
-                    <span>{{ __('El encargado ocupa un lugar de jugador') }}</span>
-                </label>
-                <small class="muted">{{ __('Desmarcá si querés liberar un asiento adicional para los jugadores.') }}</small>
-                @error('manager_counts_as_player') <div class="text-danger">{{ $message }}</div> @enderror
-            </div>
-
             {{-- Nota privada para el encargado --}}
             <div style="grid-column:1/-1">
                 <label for="manager_note">{{ __('Nota interna para el encargado (opcional)') }}</label>

--- a/resources/views/tables/notes.blade.php
+++ b/resources/views/tables/notes.blade.php
@@ -1,0 +1,211 @@
+{{-- resources/views/tables/notes.blade.php --}}
+@extends('layouts.app')
+
+@section('title', __('Notas internas de :mesa', ['mesa' => $mesa->title]) . ' · ' . config('app.name', 'La Taberna'))
+
+@push('head')
+    <style>
+        :root {
+            --muted: #6b7280;
+            --border: #e5e7eb;
+            --maroon: #7b2d26;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --muted: #a7b0ba;
+                --border: #2d2f33;
+            }
+        }
+
+        .notes-wrap {
+            max-width: 960px;
+            margin: 0 auto;
+            padding: 1rem;
+            display: grid;
+            gap: 1rem;
+        }
+
+        .notes-header {
+            display: flex;
+            flex-direction: column;
+            gap: .5rem;
+        }
+
+        .notes-header h1 {
+            margin: 0;
+            color: var(--maroon);
+        }
+
+        .notes-meta {
+            color: var(--muted);
+            font-size: .95rem;
+        }
+
+        .notes-grid {
+            display: grid;
+            gap: 1rem;
+            grid-template-columns: 2fr 1fr;
+        }
+
+        @media (max-width: 860px) {
+            .notes-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .notes-card {
+            padding: 1rem;
+            border-radius: .75rem;
+            border: 1px solid var(--border);
+            background: var(--card, #fff);
+        }
+
+        .notes-card h2 {
+            margin-top: 0;
+            color: var(--maroon);
+        }
+
+        .notes-textarea {
+            width: 100%;
+            min-height: 200px;
+            padding: .75rem;
+            border-radius: .6rem;
+            border: 1px solid var(--border);
+            resize: vertical;
+            font: inherit;
+            line-height: 1.5;
+        }
+
+        .notes-preview {
+            white-space: pre-wrap;
+            line-height: 1.6;
+        }
+
+        .notes-empty {
+            color: var(--muted);
+            background: rgba(125, 45, 38, .05);
+            border-radius: .6rem;
+            padding: .75rem;
+        }
+
+        .notes-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: grid;
+            gap: .6rem;
+        }
+
+        .notes-player {
+            display: flex;
+            align-items: center;
+            gap: .6rem;
+        }
+
+        .notes-player img {
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+            object-fit: cover;
+            border: 1px solid var(--border);
+        }
+
+        .notes-player span {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: .1rem .45rem;
+            border-radius: 999px;
+            border: 1px solid var(--border);
+            font-size: .8rem;
+            color: var(--muted);
+            margin-top: .15rem;
+            width: fit-content;
+        }
+
+        .notes-actions {
+            display: flex;
+            justify-content: flex-end;
+            margin-top: .75rem;
+        }
+
+        .notes-actions .btn {
+            min-width: 160px;
+        }
+    </style>
+@endpush
+
+@section('content')
+    <main class="notes-wrap">
+        <div class="notes-header">
+            <a class="link" href="{{ route('mesas.show', $mesa) }}">&larr; {{ __('Volver a la mesa') }}</a>
+            <h1>{{ __('Notas internas de :mesa', ['mesa' => $mesa->title]) }}</h1>
+            <p class="notes-meta">
+                {{ __('Estas notas solo son visibles para el encargado y las personas inscriptas en la mesa.') }}
+            </p>
+        </div>
+
+        <div class="notes-grid">
+            <section class="notes-card">
+                <h2>{{ $canEdit ? __('Editar notas') : __('Notas compartidas') }}</h2>
+
+                @if($canEdit)
+                    <form method="POST" action="{{ route('mesas.notes.update', $mesa) }}">
+                        @csrf
+                        @method('PUT')
+                        <label class="sr-only" for="manager_note">{{ __('Notas de la mesa') }}</label>
+                        <textarea id="manager_note"
+                                  name="manager_note"
+                                  class="notes-textarea"
+                                  placeholder="{{ __('Agregá recordatorios, pautas o enlaces útiles para tu mesa.') }}">{{ old('manager_note', $mesa->manager_note) }}</textarea>
+                        @error('manager_note')
+                            <div class="text-danger" style="margin-top:.35rem">{{ $message }}</div>
+                        @enderror
+                        <div class="notes-actions">
+                            <button class="btn ok" type="submit">{{ __('Guardar notas') }}</button>
+                        </div>
+                    </form>
+                @elseif(filled($mesa->manager_note))
+                    <div class="notes-preview">{!! nl2br(e($mesa->manager_note)) !!}</div>
+                @else
+                    <div class="notes-empty">{{ __('Todavía no hay notas cargadas.') }}</div>
+                @endif
+            </section>
+
+            <aside class="notes-card">
+                <h2>{{ __('Quiénes pueden ver esto') }}</h2>
+                <ul class="notes-list">
+                    @foreach($players as $signup)
+                        @php
+                            $u = $signup->user;
+                            $avatar = $signup->user_avatar_url;
+                            $name = $signup->user_display_name ?? ($u?->name ?? $u?->username ?? __('Usuario'));
+                        @endphp
+                        <li class="notes-player">
+                            <img src="{{ $avatar }}"
+                                 alt="{{ $name }}"
+                                 loading="lazy"
+                                 decoding="async">
+                            <span>
+                                <strong>{{ $name }}</strong>
+                                @if($signup->is_manager)
+                                    <span class="pill">{{ __('Encargado') }}</span>
+                                @elseif($signup->is_player)
+                                    <span class="pill">{{ __('Jugador/a') }}</span>
+                                @else
+                                    <span class="pill">{{ __('Lista de espera') }}</span>
+                                @endif
+                            </span>
+                        </li>
+                    @endforeach
+                </ul>
+            </aside>
+        </div>
+    </main>
+@endsection

--- a/resources/views/tables/show.blade.php
+++ b/resources/views/tables/show.blade.php
@@ -160,6 +160,13 @@
             gap: .1rem
         }
 
+        .manager-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: .5rem;
+            align-items: center;
+        }
+
         .honor-actions {
             display: flex;
             flex-wrap: wrap;
@@ -333,6 +340,15 @@
                         </div>
                     @endif
 
+                    @if($canViewNotes && \Illuminate\Support\Facades\Route::has('mesas.notes'))
+                        <div class="manager-meta">
+                            <strong>{{ __('Notas internas') }}</strong>
+                            <a class="btn"
+                               style="width:max-content"
+                               href="{{ route('mesas.notes', $mesa) }}">{{ __('Abrir notas privadas') }}</a>
+                        </div>
+                    @endif
+
                     <p class="honor-note">
                         💡 {{ __('Quien administra la mesa puede marcar asistencia, ausencias y comportamiento: el honor se actualiza en forma automática.') }}
                     </p>
@@ -341,6 +357,24 @@
                         <div class="honor-note">
                             <strong>{{ __('Nota interna') }}:</strong>
                             {!! nl2br(e($managerNote)) !!}
+                        </div>
+                    @endif
+
+                    @if(($isManager || $isAdmin) && \Illuminate\Support\Facades\Route::has('mesas.manager.playing'))
+                        <div class="manager-meta">
+                            <strong>{{ __('Tu participación como encargado') }}</strong>
+                            <form class="manager-actions"
+                                  method="POST"
+                                  action="{{ route('mesas.manager.playing', $mesa) }}">
+                                @csrf
+                                <input type="hidden" name="playing" value="{{ $managerCountsAsPlayer ? '0' : '1' }}">
+                                <button class="btn {{ $managerCountsAsPlayer ? 'danger' : 'ok' }}" type="submit">
+                                    {{ $managerCountsAsPlayer ? __('No voy a jugar') : __('Volver a jugar') }}
+                                </button>
+                                @if(!$managerCountsAsPlayer)
+                                    <span class="pill off">{{ __('Actualmente figurás solo como encargado') }}</span>
+                                @endif
+                            </form>
                         </div>
                     @endif
                 </div>
@@ -356,6 +390,10 @@
                         <h3 style="color:var(--maroon);margin-top:0">
                             {{ __('Jugadores') }} ({{ $players->count() }}/{{ (int) $mesa->capacity }})
                         </h3>
+
+                        @if(!$managerCountsAsPlayer)
+                            <p class="muted" style="margin-top:-.25rem">{{ __('El encargado no ocupa un lugar de jugador en esta mesa.') }}</p>
+                        @endif
 
                         <div class="table-wrap">
                             <table>
@@ -425,7 +463,7 @@
                                                             <label>
                                                                 {{ __('Asistencia') }}
                                                                 <select name="attended">
-                                                                    <option value="">{{ __('Sin cambios') }}</option>
+                                                                    <option value="_keep_">{{ __('Sin cambios') }}</option>
                                                                     <option value="1" @selected($s->attended === true)>{{ __('Confirmar asistencia (+10)') }}</option>
                                                                     <option value="0" @selected($s->attended === false)>{{ __('Marcar como ausente') }}</option>
                                                                 </select>
@@ -440,7 +478,7 @@
                                                             <label>
                                                                 {{ __('Comportamiento') }}
                                                                 <select name="behavior">
-                                                                    <option value="">{{ __('Sin cambios') }}</option>
+                                                                    <option value="_keep_">{{ __('Sin cambios') }}</option>
                                                                     <option value="good" @selected($s->behavior === 'good')>{{ __('Buen comportamiento (+10)') }}</option>
                                                                     <option value="regular" @selected(($s->behavior ?? 'regular') === 'regular')>{{ __('Regular (0)') }}</option>
                                                                     <option value="bad" @selected($s->behavior === 'bad')>{{ __('Mal comportamiento (-10)') }}</option>
@@ -537,7 +575,7 @@
                                                             <label>
                                                                 {{ __('Asistencia') }}
                                                                 <select name="attended">
-                                                                    <option value="">{{ __('Sin cambios') }}</option>
+                                                                    <option value="_keep_">{{ __('Sin cambios') }}</option>
                                                                     <option value="1" @selected($s->attended === true)>{{ __('Confirmar asistencia (+10)') }}</option>
                                                                     <option value="0" @selected($s->attended === false)>{{ __('Marcar como ausente') }}</option>
                                                                 </select>
@@ -552,7 +590,7 @@
                                                             <label>
                                                                 {{ __('Comportamiento') }}
                                                                 <select name="behavior">
-                                                                    <option value="">{{ __('Sin cambios') }}</option>
+                                                                    <option value="_keep_">{{ __('Sin cambios') }}</option>
                                                                     <option value="good" @selected($s->behavior === 'good')>{{ __('Buen comportamiento (+10)') }}</option>
                                                                     <option value="regular" @selected(($s->behavior ?? 'regular') === 'regular')>{{ __('Regular (0)') }}</option>
                                                                     <option value="bad" @selected($s->behavior === 'bad')>{{ __('Mal comportamiento (-10)') }}</option>

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,6 +60,11 @@ Route::name('mesas.')->prefix('mesas')->group(function () use ($authVerified) {
         Route::post('/{mesa}/open', [GameTableController::class, 'open'])->whereNumber('mesa')->name('open');
         Route::post('/{mesa}/close', [GameTableController::class, 'close'])->whereNumber('mesa')->name('close');
 
+        // Notas privadas y estado del encargado
+        Route::get('/{mesa}/notas', [GameTableController::class, 'notes'])->whereNumber('mesa')->name('notes');
+        Route::put('/{mesa}/notas', [GameTableController::class, 'updateNotes'])->whereNumber('mesa')->name('notes.update');
+        Route::post('/{mesa}/manager-playing', [GameTableController::class, 'updateManagerPlaying'])->whereNumber('mesa')->name('manager.playing');
+
         // Atajo "mi mesa"
         Route::get('/mine', [GameTableController::class, 'mine'])->name('mine');
     });


### PR DESCRIPTION
## Summary
- Renueva la portada con un héroe informativo, accesos destacados y una sección de herramientas para encargados
- Añade vista de notas privadas por mesa, controles para la participación del encargado y enlaces visibles para jugadores
- Ajusta formularios y asistencia para evitar errores al actualizar el estado de jugadores

## Testing
- `php artisan test` *(falla: falta `vendor/autoload.php` en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68e487330060832ca8fc4dc57fe4b558