### PR TITLE
Soportar columnas legacy al confirmar asistencia

### DIFF
--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -72,6 +72,25 @@ class Signup extends Model
         'no_show_by' => 'integer',
     ];
 
+    public function getAttendedAttribute($value): ?bool
+    {
+        if (array_key_exists('attended', $this->getAttributes())) {
+            return $value === null ? null : (bool) $value;
+        }
+
+        $confirmed = $this->getAttributes()['attendance_confirmed_at'] ?? null;
+        if ($confirmed !== null) {
+            return true;
+        }
+
+        $noShow = $this->getAttributes()['no_show_at'] ?? null;
+        if ($noShow !== null) {
+            return false;
+        }
+
+        return null;
+    }
+
     /** Tocar la mesa al cambiar un signup (para ordenar por actividad) */
     protected $touches = ['gameTable'];
 


### PR DESCRIPTION
## Summary
- sincronizar el flujo de AttendanceController con las columnas antiguas de asistencia cuando la tabla `signups` aún no tiene las banderas nuevas
- mantener coherencia entre confirmaciones, no shows y eventos de honor sin lanzar excepciones por columnas faltantes
- exponer el estado de asistencia derivado en el modelo para que la interfaz muestre el estado correcto incluso con el esquema anterior

## Testing
- not run (composer install bloqueado por GitHub 403)


------
https://chatgpt.com/codex/tasks/task_e_68e48b1130fc832ca45bd8af6ae33833