### PR TITLE
Fix honor recalculation after undo actions

### DIFF
--- a/app/Services/HonorRules.php
+++ b/app/Services/HonorRules.php
@@ -21,13 +21,18 @@ final class HonorRules
         [$user, $mesa] = $this->loadSignupMin($signup);
 
         $slug = "mesa:{$mesa->id}:signup:{$signup->id}:attended";
-
-        return $user->addHonor(
+        $event = $user->addHonor(
             10,
             HonorEvent::R_ATTEND_OK,
             ['mesa_id' => (int) $mesa->id, 'signup_id' => (int) $signup->id, 'by' => (int) $manager->id],
             $slug
         );
+
+        if (method_exists($user, 'removeHonorEventBySlug')) {
+            $user->removeHonorEventBySlug("{$slug}:undo");
+        }
+
+        return $event;
     }
 
     /**
@@ -70,12 +75,22 @@ final class HonorRules
         // Un encargado (manager) puede votar una sola vez por tipo para ese signup
         $slug = "mesa:{$mesa->id}:signup:{$signup->id}:behavior:{$type}:by:{$manager->id}";
 
-        return $user->addHonor(
+        $event = $user->addHonor(
             $points,
             $reason,
             ['mesa_id' => (int) $mesa->id, 'signup_id' => (int) $signup->id, 'by' => (int) $manager->id],
             $slug
         );
+
+        if ($type === 'good' && method_exists($user, 'removeHonorEventBySlug')) {
+            $user->removeHonorEventBySlug("mesa:{$mesa->id}:signup:{$signup->id}:behavior:undo:good");
+        }
+
+        if ($type === 'bad' && method_exists($user, 'removeHonorEventBySlug')) {
+            $user->removeHonorEventBySlug("mesa:{$mesa->id}:signup:{$signup->id}:behavior:undo:bad");
+        }
+
+        return $event;
     }
 
     /* ========================= Helpers ========================= */

--- a/tests/Feature/HonorFlowTest.php
+++ b/tests/Feature/HonorFlowTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\AttendanceController;
+use App\Models\GameTable;
+use App\Models\Signup;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class HonorFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_reconfirm_attendance_restores_positive_honor(): void
+    {
+        $manager = User::factory()->create();
+        $player = User::factory()->create();
+
+        $mesa = GameTable::create([
+            'title' => 'Mesa de prueba',
+            'capacity' => 5,
+            'created_by' => $manager->id,
+            'is_open' => true,
+        ]);
+
+        $signup = Signup::create([
+            'game_table_id' => $mesa->id,
+            'user_id' => $player->id,
+            'is_counted' => true,
+            'is_manager' => false,
+            'attended' => false,
+            'behavior' => 'regular',
+        ]);
+
+        $controller = app(AttendanceController::class);
+
+        // Primera confirmación: +10
+        $this->callAttendanceUpdate($controller, $manager, $mesa, $signup, ['attended' => true]);
+
+        // Desconfirmar: agrega evento de undo (-10)
+        $signup->refresh();
+        $this->callAttendanceUpdate($controller, $manager, $mesa, $signup, ['attended' => false]);
+        $this->assertDatabaseHas('honor_events', [
+            'slug' => "mesa:{$mesa->id}:signup:{$signup->id}:attended:undo",
+            'points' => -10,
+        ]);
+
+        // Reconirmar: debe limpiar el undo y dejar +10 neto
+        $signup->refresh();
+        $this->callAttendanceUpdate($controller, $manager, $mesa, $signup, ['attended' => true]);
+
+        $this->assertDatabaseMissing('honor_events', [
+            'slug' => "mesa:{$mesa->id}:signup:{$signup->id}:attended:undo",
+        ]);
+
+        $this->assertSame(10, $player->refresh()->refreshHonorAggregate());
+    }
+
+    public function test_behavior_good_clears_previous_undo(): void
+    {
+        $manager = User::factory()->create();
+        $player = User::factory()->create();
+
+        $mesa = GameTable::create([
+            'title' => 'Mesa de conducta',
+            'capacity' => 4,
+            'created_by' => $manager->id,
+            'is_open' => true,
+        ]);
+
+        $signup = Signup::create([
+            'game_table_id' => $mesa->id,
+            'user_id' => $player->id,
+            'is_counted' => true,
+            'is_manager' => false,
+            'attended' => false,
+            'behavior' => 'regular',
+        ]);
+
+        $controller = app(AttendanceController::class);
+
+        // Marcar comportamiento bueno (+10)
+        $this->callAttendanceUpdate($controller, $manager, $mesa, $signup, ['behavior' => 'good']);
+
+        // Volver a regular crea undo (-10)
+        $signup->refresh();
+        $this->callAttendanceUpdate($controller, $manager, $mesa, $signup, ['behavior' => 'regular']);
+        $undoSlug = "mesa:{$mesa->id}:signup:{$signup->id}:behavior:undo:good";
+        $this->assertDatabaseHas('honor_events', [
+            'slug' => $undoSlug,
+            'points' => -10,
+        ]);
+
+        // Marcar de nuevo como good debe eliminar el undo y dejar el +10
+        $signup->refresh();
+        $this->callAttendanceUpdate($controller, $manager, $mesa, $signup, ['behavior' => 'good']);
+
+        $this->assertDatabaseMissing('honor_events', ['slug' => $undoSlug]);
+        $this->assertSame(10, $player->refresh()->refreshHonorAggregate());
+    }
+
+    private function callAttendanceUpdate(
+        AttendanceController $controller,
+        User $manager,
+        GameTable $mesa,
+        Signup $signup,
+        array $payload
+    ): void {
+        $request = Request::create('/mesas/' . $mesa->id, 'POST', $payload);
+        $request->setUserResolver(fn() => $manager);
+
+        $controller->update($request, $mesa->fresh(), $signup->fresh());
+    }
+}
+


### PR DESCRIPTION
## Summary
- clear undo honor events when re-confirming attendance or reapplying good/bad behaviour so totals update again
- add a reusable helper on the HasHonor mixin to remove events by slug and use it from controllers/services
- cover the honour flow with feature tests to avoid regressions when toggling attendance or behaviour

## Testing
- php -l app/Http/Controllers/AttendanceController.php
- php -l app/Models/Concerns/HasHonor.php
- php -l app/Services/HonorRules.php
- php -l tests/Feature/HonorFlowTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e4969d247c832c81a77b8fcbce85be