### PR TITLE
Avoid skipping honor column migration when the users table is absent

### DIFF
--- a/database/migrations/2025_10_06_000004_add_honor_to_users_table.php
+++ b/database/migrations/2025_10_06_000004_add_honor_to_users_table.php
@@ -7,12 +7,17 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-        if (!Schema::hasTable('users') || Schema::hasColumn('users', 'honor')) {
+        // No regresamos si falta la tabla "users": si este archivo se ejecuta
+        // antes de crearla (p. ej. usando --path), la migración quedaría
+        // marcada como corrida sin agregar la columna y no volvería a intentar.
+        if (Schema::hasColumn('users', 'honor')) {
             return;
         }
 
         Schema::table('users', function (Blueprint $table) {
-            $table->integer('honor')->default(0);
+            if (!Schema::hasColumn('users', 'honor')) {
+                $table->integer('honor')->default(0);
+            }
         });
     }
 
@@ -23,7 +28,9 @@ return new class extends Migration {
         }
 
         Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('honor');
+            if (Schema::hasColumn('users', 'honor')) {
+                $table->dropColumn('honor');
+            }
         });
     }
 };


### PR DESCRIPTION
## Summary
- prevent the honor column migration from exiting early when the `users` table is still pending creation
- wrap the column operations with additional guards so the migration only adds or drops the field when required

## Testing
- not run (composer install failed: GitHub API access blocked in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4a34af2f4832c85deb21c6136fee4