### PR TITLE
Fix honor persistence and ranking fallback

### DIFF
--- a/resources/views/ranking/index.blade.php
+++ b/resources/views/ranking/index.blade.php
@@ -74,7 +74,7 @@
                             <a href="{{ route('profile.show', $u) }}">{{ $u->name ?? 'Usuario ' . $u->id }}</a>
                             @if($u->username) <span class="pill">@{{ $u->username }}</span> @endif
                         </td>
-                        <td style="text-align:right">{{ (int) $u->honor_total }}</td>
+                        <td style="text-align:right">{{ number_format((int) $u->honor_total, 0, ',', '.') }}</td>
                     </tr>
                 @endforeach
             </tbody>

--- a/tests/Feature/HonorRankingFallbackTest.php
+++ b/tests/Feature/HonorRankingFallbackTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class HonorRankingFallbackTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ranking_uses_users_honor_when_events_table_missing(): void
+    {
+        Schema::dropIfExists('honor_events');
+
+        $alice = User::factory()->create(['name' => 'Alice Test']);
+        $bob = User::factory()->create(['name' => 'Bob Test']);
+        $charlie = User::factory()->create(['name' => 'Charlie Test']);
+
+        DB::table('users')->where('id', $alice->id)->update(['honor' => 40]);
+        DB::table('users')->where('id', $bob->id)->update(['honor' => 120]);
+        DB::table('users')->where('id', $charlie->id)->update(['honor' => 10]);
+
+        $response = $this->actingAs($alice)->get(route('ranking.honor'));
+        $response->assertOk();
+
+        /** @var \Illuminate\Pagination\LengthAwarePaginator $users */
+        $users = $response->viewData('users');
+
+        $this->assertSame([
+            $bob->id,
+            $alice->id,
+            $charlie->id,
+        ], $users->pluck('id')->all());
+
+        $this->assertSame([
+            120,
+            40,
+            10,
+        ], $users->pluck('honor_total')->map(fn ($v) => (int) $v)->all());
+
+        $this->assertStringContainsString('#2', $response->getContent());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the honor ranking works whether the honor_events table is available or only the persisted users.honor column
- show the persisted honor total on the dashboard and format totals in the honor ranking table
- cover the fallback scenario with a new feature test

## Testing
- `php artisan test` *(fails locally: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a848981c832c803b45db442ac88d