### PR TITLE
Fix honor event persistence on constrained MySQL setups

### DIFF
--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -314,6 +314,13 @@ class AttendanceController extends Controller
      */
     private function addHonorSafe(User $user, int $points, string $reason, array $meta, string $slug): bool
     {
+        $slug = trim($slug);
+        if ($slug === '') {
+            $slug = null;
+        } elseif ($slug !== null && \strlen($slug) > 191) {
+            $slug = \substr($slug, 0, 191);
+        }
+
         try {
             if (method_exists($user, 'addHonor')) {
                 $event = $user->addHonor($points, $reason, $meta, $slug);

--- a/database/migrations/2025_10_06_000000_create_honor_events_table.php
+++ b/database/migrations/2025_10_06_000000_create_honor_events_table.php
@@ -13,7 +13,9 @@ return new class extends Migration {
             $t->integer('points');
             $t->string('reason')->nullable();
             $t->json('meta')->nullable();
-            $t->string('slug')->nullable(); // idempotencia por acción (único por user)
+            // Longitud 191 => compatible con índices UNIQUE en MySQL/MariaDB utf8mb4
+            // sin depender de Schema::defaultStringLength().
+            $t->string('slug', 191)->nullable(); // idempotencia por acción (único por user)
             $t->timestamps();
 
             $t->index('user_id');


### PR DESCRIPTION
## Summary
- limit the `honor_events.slug` column to 191 characters so the unique index works on utf8mb4 MySQL/MariaDB installations without extra configuration
- normalize slugs in the fallback honor insert path to mirror the trait behaviour and keep inserts safe

## Testing
- not run (composer install fails in this environment because GitHub API requires authentication)


------
https://chatgpt.com/codex/tasks/task_e_68e4abbc033c832c8a7611b65dfe8bb6