### PR TITLE
Consolidate authentication helpers in base controller

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\User;
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -100,6 +101,28 @@ class Controller extends BaseController
             $pp = $max;
 
         return $pp;
+    }
+
+    /* =========================
+     *  AUTH HELPERS
+     * ========================= */
+
+    /** Obtiene el usuario autenticado tipado o null. */
+    protected function optionalUser(Request $request): ?User
+    {
+        $user = $request->user();
+
+        return $user instanceof User ? $user : null;
+    }
+
+    /** Obtiene el usuario autenticado tipado o aborta con 403. */
+    protected function requireUser(Request $request): User
+    {
+        $user = $this->optionalUser($request);
+
+        abort_unless($user instanceof User, 403);
+
+        return $user;
     }
 
     /* =========================

--- a/app/Http/Controllers/GameTableController.php
+++ b/app/Http/Controllers/GameTableController.php
@@ -391,21 +391,6 @@ class GameTableController extends Controller
         abort_unless($isOwner || $isManager || $isAdmin, 403);
     }
 
-    /** Devuelve el usuario autenticado tipado o aborta 403 (quita warnings) */
-    private function requireUser(Request $request): User
-    {
-        $u = $request->user();
-        abort_unless($u instanceof User, 403);
-        return $u;
-    }
-
-    /** Devuelve el usuario autenticado tipado o null (para vistas públicas) */
-    private function optionalUser(Request $request): ?User
-    {
-        $u = $request->user();
-        return $u instanceof User ? $u : null;
-    }
-
     private function validateTable(Request $request): array
     {
         return $this->validateInput($request, [

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Models\GameTable;
 use App\Models\Signup;
-use App\Models\User; // ← para tipar el auth user y evitar warnings
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use Illuminate\Http\Request;
@@ -148,13 +147,6 @@ class HomeController extends Controller
             : Carbon::parse((string) $opensRaw, $tz);
 
         return $this->nowTz()->greaterThanOrEqualTo($openAt);
-    }
-
-    /** Devuelve el usuario autenticado tipado o null (evita warning del IDE) */
-    private function optionalUser(Request $request): ?User
-    {
-        $u = $request->user();
-        return $u instanceof User ? $u : null;
     }
 
     /**

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -208,14 +208,6 @@ class ProfileController extends Controller
      * Helpers privados
      * ========================= */
 
-    /** Asegura user autenticado tipado (evita warnings del IDE) */
-    private function requireUser(Request $request): User
-    {
-        $u = $request->user();
-        abort_unless($u instanceof User, 403);
-        return $u;
-    }
-
     private function avatarDisk(): string
     {
         return (string) config('users.avatar_disk', config('filesystems.default', 'public'));

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -176,14 +176,6 @@ final class SignupController extends Controller
 
     /* ========================= Helpers ========================= */
 
-    /** Devuelve el usuario autenticado tipado o aborta 403 (evita warnings del IDE) */
-    private function requireUser(Request $request): User
-    {
-        $u = $request->user();
-        abort_unless($u instanceof User, 403);
-        return $u;
-    }
-
     /** ¿La mesa está abierta "ahora"? Usa huso de pantalla del Controller. */
     private function mesaIsOpenNow(GameTable $mesa): bool
     {


### PR DESCRIPTION
## Summary
- add reusable optionalUser/requireUser helpers to the base Controller
- remove duplicated authentication helper implementations from feature controllers

## Testing
- php artisan test *(fails: vendor/autoload.php missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b6ed2be0832c850f91d33a1ac4cf