### PR TITLE
Refine data layer constraints and provider configuration

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -25,101 +25,60 @@ class AuthServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        // Registra las policies declaradas arriba
         $this->registerPolicies();
 
-        // Roles administradores y “super habilidad” desde config (con defaults)
         $adminRoles = (array) config('auth.admin_roles', ['admin']);
-        $superAbility = (string) config('auth.super_ability', 'superadmin'); // permiso que otorga TODO
+        $superAbility = (string) config('auth.super_ability', 'superadmin');
 
-        /**
-         * Gate::before => atajo: si el usuario es superadmin o admin, autoriza todo.
-         * IMPORTANTE: evitar $user->can($superAbility) para no provocar recursión.
-         */
-        Gate::before(function (?User $user, string $ability) use ($adminRoles, $superAbility) {
+        $this->configureGateOverrides($adminRoles, $superAbility);
+        $this->defineAdminGate($adminRoles);
+        $this->defineManageTablesGate();
+        $this->logDeniedGateDecisions();
+    }
+
+    private function configureGateOverrides(array $adminRoles, string $superAbility): void
+    {
+        Gate::before(function (?User $user) use ($adminRoles, $superAbility) {
             if (!$user) {
-                return null; // invitado => seguir flujo normal
+                return null;
             }
 
-            // 1) Super habilidad sin pasar por Gate (Spatie o flag propio)
-            if ($superAbility) {
-                // Spatie Permissions (si lo usás)
-                if (method_exists($user, 'hasPermissionTo') && $user->hasPermissionTo($superAbility)) {
-                    return true;
-                }
-                // Alternativa si NO usás Spatie: booleano/atributo en users
-                if (
-                    (property_exists($user, 'is_superadmin') && $user->is_superadmin)
-                    || (isset($user->is_superadmin) && (bool) $user->is_superadmin)
-                ) {
-                    return true;
-                }
-            }
-
-            // 2) Roles admin (Spatie)
-            if (method_exists($user, 'hasAnyRole') && $user->hasAnyRole($adminRoles)) {
-                return true;
-            }
-            if (method_exists($user, 'hasRole')) {
-                foreach ($adminRoles as $role) {
-                    if ($user->hasRole($role)) {
-                        return true;
-                    }
-                }
-            }
-
-            // 3) Campo plano 'role' en users
-            if (isset($user->role) && in_array($user->role, $adminRoles, true)) {
+            if ($superAbility && $this->userHasAbility($user, $superAbility)) {
                 return true;
             }
 
-            return null; // seguimos con la evaluación normal
+            if ($this->userIsAdmin($user, $adminRoles)) {
+                return true;
+            }
+
+            return null;
         });
+    }
 
-        /**
-         * Gate: 'admin' => acceso de administración.
-         * Devuelve Response con mensaje para un 403 más claro.
-         */
+    private function defineAdminGate(array $adminRoles): void
+    {
         Gate::define('admin', function (?User $user) use ($adminRoles) {
             if (!$user) {
                 return Response::deny('Necesitás iniciar sesión.');
             }
 
-            // Spatie (roles)
-            if (method_exists($user, 'hasAnyRole') && $user->hasAnyRole($adminRoles)) {
-                return Response::allow();
-            }
-            if (method_exists($user, 'hasRole')) {
-                foreach ($adminRoles as $role) {
-                    if ($user->hasRole($role)) {
-                        return Response::allow();
-                    }
-                }
-            }
-
-            // Campo 'role' plano
-            if (isset($user->role) && in_array($user->role, $adminRoles, true)) {
-                return Response::allow();
-            }
-
-            return Response::deny('Solo administradores.');
+            return $this->userIsAdmin($user, $adminRoles)
+                ? Response::allow()
+                : Response::deny('Solo administradores.');
         });
+    }
 
-        /**
-         * Ejemplo de gate granular (ajustá/duplicá según tu dominio).
-         * Útil si querés chequear permisos sin escribir una Policy completa.
-         */
+    private function defineManageTablesGate(): void
+    {
         Gate::define('manage-tables', function (?User $user) {
             if (!$user) {
                 return Response::deny('Necesitás iniciar sesión.');
             }
 
-            // Los admins pasan directo (Gate::before ya los autoriza, pero esto lo hace explícito)
             if (Gate::forUser($user)->allows('admin')) {
                 return Response::allow();
             }
 
-            // Si usás Spatie/permissions (permiso nominal)
             if (
                 (method_exists($user, 'can') && $user->can('manage tables'))
                 || (method_exists($user, 'hasPermissionTo') && $user->hasPermissionTo('manage tables'))
@@ -129,23 +88,54 @@ class AuthServiceProvider extends ServiceProvider
 
             return Response::deny('No tenés permisos para administrar mesas.');
         });
+    }
 
-        /**
-         * Logging de decisiones en entornos de desarrollo/test
-         * (ayuda a entender por qué se denegó algo).
-         */
-        if (app()->environment(['local', 'testing'])) {
-            Gate::after(function (?User $user, string $ability, ?bool $result, array $arguments = []) {
-                if ($result === false) {
-                    Log::info('Gate denegada', [
-                        'user_id' => $user?->id,
-                        'ability' => $ability,
-                        'args' => $arguments,
-                        'user_role' => $user->role ?? null,
-                    ]);
-                }
-                return null; // no sobreescribe el resultado
-            });
+    private function logDeniedGateDecisions(): void
+    {
+        if (!app()->environment(['local', 'testing'])) {
+            return;
         }
+
+        Gate::after(function (?User $user, string $ability, ?bool $result, array $arguments = []) {
+            if ($result === false) {
+                Log::info('Gate denegada', [
+                    'user_id' => $user?->id,
+                    'ability' => $ability,
+                    'args' => $arguments,
+                    'user_role' => $user->role ?? null,
+                ]);
+            }
+
+            return null;
+        });
+    }
+
+    private function userIsAdmin(User $user, array $adminRoles): bool
+    {
+        if (method_exists($user, 'hasAnyRole') && $user->hasAnyRole($adminRoles)) {
+            return true;
+        }
+
+        if (method_exists($user, 'hasRole')) {
+            foreach ($adminRoles as $role) {
+                if ($user->hasRole($role)) {
+                    return true;
+                }
+            }
+        }
+
+        return isset($user->role) && in_array($user->role, $adminRoles, true);
+    }
+
+    private function userHasAbility(User $user, string $superAbility): bool
+    {
+        if (method_exists($user, 'hasPermissionTo') && $user->hasPermissionTo($superAbility)) {
+            return true;
+        }
+
+        return (
+            (property_exists($user, 'is_superadmin') && $user->is_superadmin)
+            || (isset($user->is_superadmin) && (bool) $user->is_superadmin)
+        );
     }
 }

--- a/database/migrations/2025_10_04_000000_create_game_tables_table.php
+++ b/database/migrations/2025_10_04_000000_create_game_tables_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -10,9 +11,9 @@ return new class extends Migration {
         Schema::create('game_tables', function (Blueprint $table) {
             $table->id();
 
-            $table->string('title');
+            $table->string('title', 120);
             $table->text('description')->nullable();
-            $table->unsignedInteger('capacity');
+            $table->unsignedSmallInteger('capacity');
 
             $table->string('image_path')->nullable();
             $table->string('image_url', 2048)->nullable();
@@ -21,13 +22,15 @@ return new class extends Migration {
             $table->timestamp('opens_at')->nullable()->index();
             $table->timestamp('closed_at')->nullable()->index();
 
-            $table->foreignId('created_by')->constrained('users')->cascadeOnDelete();
-            $table->foreignId('manager_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignIdFor(User::class, 'created_by')->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(User::class, 'manager_id')->nullable()->constrained()->nullOnDelete();
             $table->boolean('manager_counts_as_player')->default(true);
             $table->text('manager_note')->nullable();
             $table->string('join_url', 2048)->nullable();
 
             $table->timestamps();
+
+            $table->index(['is_open', 'opens_at'], 'game_tables_opening_window_index');
         });
     }
     public function down(): void

--- a/database/migrations/2025_10_04_010000_create_signups_table.php
+++ b/database/migrations/2025_10_04_010000_create_signups_table.php
@@ -25,9 +25,10 @@ return new class extends Migration {
 
             $table->timestamps();
 
-            $table->unique('user_id', 'signups_user_id_unique');
+            $table->index('user_id', 'signups_user_id_index');
             $table->unique(['game_table_id', 'user_id'], 'signups_game_table_id_user_id_unique');
             $table->index(['game_table_id', 'created_at'], 'signups_game_table_id_created_at_index');
+            $table->index(['game_table_id', 'attended'], 'signups_attendance_lookup_index');
         });
     }
     public function down(): void

--- a/database/migrations/2025_10_05_000000_create_vote_histories_table.php
+++ b/database/migrations/2025_10_05_000000_create_vote_histories_table.php
@@ -14,7 +14,7 @@ return new class extends Migration {
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->foreignId('game_table_id')->nullable()->constrained('game_tables')->nullOnDelete();
 
-            $table->string('game_title', 200);
+            $table->string('game_title', 191);
             $table->string('kind', 12)->default('close')->index(); // 'close'
             $table->timestamp('happened_at')->nullable()->index(); // fecha mostrada
 
@@ -22,6 +22,7 @@ return new class extends Migration {
 
             // Un cierre por usuario/mesa
             $table->unique(['user_id', 'game_table_id', 'kind'], 'vh_user_table_kind_unique');
+            $table->index(['game_table_id', 'kind'], 'vh_table_kind_index');
         });
     }
 

--- a/database/migrations/2025_10_06_000000_create_honor_events_table.php
+++ b/database/migrations/2025_10_06_000000_create_honor_events_table.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use App\Models\User;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -9,7 +10,7 @@ return new class extends Migration {
     {
         Schema::create('honor_events', function (Blueprint $t) {
             $t->id();
-            $t->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $t->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
             $t->integer('points');
             $t->string('reason')->nullable();
             $t->json('meta')->nullable();

--- a/database/migrations/2025_10_06_000001_create_mesa_managers_table.php
+++ b/database/migrations/2025_10_06_000001_create_mesa_managers_table.php
@@ -1,6 +1,8 @@
 <?php
 
 // database/migrations/2025_10_06_000001_create_mesa_managers_table.php
+use App\Models\GameTable;
+use App\Models\User;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -10,11 +12,12 @@ return new class extends Migration {
     {
         Schema::create('mesa_managers', function (Blueprint $t) {
             $t->id();
-            $t->foreignId('mesa_id')->constrained('game_tables')->cascadeOnDelete();
-            $t->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $t->foreignIdFor(GameTable::class, 'mesa_id')->constrained('game_tables')->cascadeOnDelete();
+            $t->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
             $t->timestamps();
 
             $t->unique(['mesa_id', 'user_id']);
+            $t->index('user_id');
         });
     }
 


### PR DESCRIPTION
## Summary
- refactor the application and auth service providers into smaller focused helpers while keeping existing behaviour intact
- tighten the domain migrations by using model-aware foreign keys, tuned column lengths, and additional indexes for frequent lookups
- fix the signups constraints so a user can join multiple tables while still enforcing per-table uniqueness

## Testing
- php artisan test *(fails: missing vendor/autoload.php in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ba7c8be8832cb3bf47328af6765a