### PR TITLE
Fix fatal error when opening mesa creation view

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -100,9 +100,8 @@
                 <a class="btn"
                    href="{{ route('mesas.index') }}">Mesas</a>
 
-                @php use Illuminate\Support\Facades\Route as RouteFacade; @endphp
                 @can('manage-tables')
-                    @if(RouteFacade::has('mesas.create'))
+                    @if(\Illuminate\Support\Facades\Route::has('mesas.create'))
                         <a class="btn gold"
                            href="{{ route('mesas.create') }}">➕ Nueva mesa</a>
                     @endif

--- a/resources/views/tables/create.blade.php
+++ b/resources/views/tables/create.blade.php
@@ -40,11 +40,10 @@
 
 @section('content')
     @php
-        use Carbon\Carbon;
         $tz = config('app.display_timezone', config('app.timezone', 'UTC'));
         $opensAtObj = filled(old('opens_at'))
-            ? Carbon::parse(old('opens_at'), $tz)
-            : Carbon::now($tz)->setTime(22, 15, 0);
+            ? \Carbon\Carbon::parse(old('opens_at'), $tz)
+            : \Carbon\Carbon::now($tz)->setTime(22, 15, 0);
         $opensAtValue = $opensAtObj->format('Y-m-d\TH:i');
         $managerCandidates = collect($managerCandidates ?? []);
     @endphp


### PR DESCRIPTION
## Summary
- remove inline `@php use` statements from Blade templates that caused runtime fatals
- reference Carbon via its fully qualified name when computing the default open time on the mesa creation form

## Testing
- not run (composer install failed due to repeated GitHub 403 responses)


------
https://chatgpt.com/codex/tasks/task_e_68e518afa844832ca6e58a2b1f68de3f