### PR TITLE
Fix admin-only middleware alias for mesa management routes

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -70,6 +70,7 @@ final class Kernel extends HttpKernel
 
         // Custom
         'admin' => \App\Http\Middleware\AdminOnly::class,
+        'admin.only' => \App\Http\Middleware\AdminOnly::class,
     ];
 
     /**
@@ -90,6 +91,7 @@ final class Kernel extends HttpKernel
 
         // Custom
         'admin' => \App\Http\Middleware\AdminOnly::class,
+        'admin.only' => \App\Http\Middleware\AdminOnly::class,
     ];
 
     /**


### PR DESCRIPTION
## Summary
- register the `admin.only` middleware alias in the HTTP kernel so routes using it resolve correctly

## Testing
- php artisan test *(fails: vendor dependencies not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e51bea00e0832cbe5d5345ae3ffd3a