### PR TITLE
Add static asset fallback for mesas pages

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,0 +1,174 @@
+:root {
+    --bg: #f8fafc;
+    --ink: #111827;
+    --muted: #6b7280;
+    --maroon: #7b2d26;
+    --border: #e5e7eb;
+    --gold: #fbbf24;
+    --red: #ef4444;
+    --green: #22c55e;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background: var(--bg);
+    color: var(--ink);
+    line-height: 1.6;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.bg-gray-50 {
+    background: #f9fafb;
+}
+
+.text-gray-900 {
+    color: #111827;
+}
+
+.border-b {
+    border-bottom: 1px solid var(--border);
+}
+
+.bg-white {
+    background: #ffffff;
+}
+
+.container {
+    width: 100%;
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 1rem;
+}
+
+.flex {
+    display: flex;
+}
+
+.items-center {
+    align-items: center;
+}
+
+.justify-between {
+    justify-content: space-between;
+}
+
+.gap-2 {
+    gap: .5rem;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    gap: .5rem;
+    border: 1px solid var(--border);
+    border-radius: .75rem;
+    padding: .5rem .9rem;
+    background: #ffffff;
+    color: inherit;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.btn:hover {
+    text-decoration: none;
+    background: #f3f4f6;
+}
+
+.btn.gold {
+    background: #fef3c7;
+    border-color: var(--gold);
+}
+
+.btn.red {
+    background: #fee2e2;
+    border-color: var(--red);
+}
+
+.btn.green {
+    background: #dcfce7;
+    border-color: var(--green);
+}
+
+.card {
+    background: #ffffff;
+    border: 1px solid var(--border);
+    border-radius: 1rem;
+    padding: 1rem;
+}
+
+.muted {
+    color: var(--muted);
+}
+
+.mb-3 {
+    margin-bottom: 1rem;
+}
+
+.bg-green-50 {
+    background: #ecfdf5;
+}
+
+.border-green-300 {
+    border-color: #86efac;
+}
+
+.bg-red-50 {
+    background: #fef2f2;
+}
+
+.border-red-300 {
+    border-color: #fca5a5;
+}
+
+.text-sm {
+    font-size: .875rem;
+}
+
+.text-gray-500 {
+    color: #6b7280;
+}
+
+.mt-8 {
+    margin-top: 2rem;
+}
+
+.py-6 {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+}
+
+.text-center {
+    text-align: center;
+}
+
+.avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 999px;
+    object-fit: cover;
+}
+
+.grid-2 {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+}
+
+@media (min-width: 900px) {
+    .grid-2 {
+        grid-template-columns: 2fr 1fr;
+    }
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,0 +1,16 @@
+(() => {
+    const meta = document.querySelector('meta[name="server-now-ms"]');
+    if (!meta) {
+        return;
+    }
+
+    const serverValue = Number(meta.getAttribute('content'));
+    if (!Number.isFinite(serverValue)) {
+        return;
+    }
+
+    const skewMs = serverValue - Date.now();
+    window.mesasNowMs = function () {
+        return Date.now() + skewMs;
+    };
+})();

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -4,13 +4,27 @@
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
 <head>
+    @php($appName = config('app.name', 'La Taberna'))
     <meta charset="utf-8">
-    <meta name="viewport"
-          content="width=device-width, initial-scale=1">
-    <title>@yield('title', config('app.name', 'La Taberna'))</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <meta name="server-now-ms" content="{{ now('UTC')->valueOf() }}">
+    <title>@yield('title', $appName)</title>
 
-    {{-- Tailwind (si usás Vite/Laravel Mix, reemplazá por @vite) --}}
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @php
+        $viteManifest = public_path('build/manifest.json');
+        $viteHot = public_path('hot');
+        $hasViteBuild = file_exists($viteManifest) || file_exists($viteHot);
+    @endphp
+
+    @if ($hasViteBuild)
+        {{-- Usa assets generados por Vite si existen --}}
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @else
+        {{-- Fallback liviano para hosting compartido (sin Node/Vite) --}}
+        <link rel="stylesheet" href="{{ asset('css/app.css') }}">
+        <script src="{{ asset('js/app.js') }}" defer></script>
+    @endif
 
     @stack('head')
 


### PR DESCRIPTION
## Summary
- add a conditional asset loader in the main layout so pages still render when a Vite build is not present
- provide lightweight CSS and JavaScript files under `public/` for shared-hosting deployments

## Testing
- not run (vendor directory missing in container)


------
https://chatgpt.com/codex/tasks/task_e_68e52f896fcc832ca98bb74699e8296f