### PR TITLE
Update layout styling with tavern-inspired palette

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,12 +1,16 @@
 :root {
-    --bg: #f8fafc;
-    --ink: #111827;
-    --muted: #6b7280;
-    --maroon: #7b2d26;
-    --border: #e5e7eb;
-    --gold: #fbbf24;
-    --red: #ef4444;
-    --green: #22c55e;
+    --bg: #F6EADF;
+    --card: #FFF7EE;
+    --ink: #2E2724;
+    --muted: #6F655E;
+    --line: #E2D3C2;
+    --maroon: #7B1E1E;
+    --maroon-press: #671717;
+    --gold: #C8A24C;
+    --gold-press: #AD8C3D;
+    --focus: #2E6FEA22;
+    --red: #C74242;
+    --green: #2F855A;
 }
 
 * {
@@ -15,31 +19,32 @@
 
 body {
     margin: 0;
-    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-family: 'Nunito Sans', system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     background: var(--bg);
     color: var(--ink);
     line-height: 1.6;
 }
 
 a {
-    color: inherit;
+    color: var(--maroon);
     text-decoration: none;
 }
 
 a:hover {
+    color: var(--maroon-press);
     text-decoration: underline;
 }
 
 .bg-gray-50 {
-    background: #f9fafb;
+    background: var(--bg);
 }
 
 .text-gray-900 {
-    color: #111827;
+    color: var(--ink);
 }
 
 .border-b {
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid var(--line);
 }
 
 .bg-white {
@@ -48,9 +53,9 @@ a:hover {
 
 .container {
     width: 100%;
-    max-width: 1000px;
+    max-width: 1100px;
     margin: 0 auto;
-    padding: 1rem;
+    padding: clamp(.9rem, 3vw, 1.4rem);
 }
 
 .flex {
@@ -72,41 +77,89 @@ a:hover {
 .btn {
     display: inline-flex;
     align-items: center;
-    gap: .5rem;
-    border: 1px solid var(--border);
-    border-radius: .75rem;
-    padding: .5rem .9rem;
-    background: #ffffff;
-    color: inherit;
+    justify-content: center;
+    gap: .55rem;
+    border-radius: .85rem;
+    padding: .55rem .95rem;
+    border: 1px solid var(--line);
+    background: var(--card);
+    color: var(--ink);
     cursor: pointer;
     text-decoration: none;
+    font-weight: 600;
+    letter-spacing: .01em;
+    transition: transform .2s ease, box-shadow .2s ease, background .2s ease;
+    box-shadow: 0 8px 20px rgba(78, 41, 27, .08);
 }
 
 .btn:hover {
-    text-decoration: none;
-    background: #f3f4f6;
+    background: #fff;
+    box-shadow: 0 12px 26px rgba(78, 41, 27, .12);
+    transform: translateY(-1px);
+}
+
+.btn.ok {
+    background: linear-gradient(135deg, var(--maroon), var(--maroon-press));
+    border-color: transparent;
+    color: #fff7ee;
+    box-shadow: 0 12px 26px rgba(123, 30, 30, .28);
+}
+
+.btn.ok:hover {
+    transform: translateY(-1px) scale(1.01);
 }
 
 .btn.gold {
-    background: #fef3c7;
-    border-color: var(--gold);
+    background: linear-gradient(135deg, var(--gold), var(--gold-press));
+    border-color: transparent;
+    color: #2D241E;
+    box-shadow: 0 12px 26px rgba(200, 162, 76, .32);
 }
 
-.btn.red {
-    background: #fee2e2;
-    border-color: var(--red);
+.btn.gold:hover {
+    transform: translateY(-1px) scale(1.01);
 }
 
-.btn.green {
-    background: #dcfce7;
-    border-color: var(--green);
+.btn.red,
+.btn.danger {
+    background: linear-gradient(135deg, #d66b6b, #b93838);
+    border-color: transparent;
+    color: #fff7ee;
+    box-shadow: 0 10px 22px rgba(182, 56, 56, .28);
+}
+
+.btn.green,
+.btn.success {
+    background: linear-gradient(135deg, #63b588, #2f855a);
+    border-color: transparent;
+    color: #0f2d1d;
+    box-shadow: 0 10px 22px rgba(47, 133, 90, .28);
+}
+
+.btn[disabled] {
+    opacity: .6;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.btn.block {
+    width: 100%;
+    justify-content: center;
+    font-size: 1.02rem;
+    padding: .75rem 1rem;
+}
+
+.btn.active,
+.btn[aria-current="page"] {
+    box-shadow: inset 0 0 0 2px var(--maroon);
 }
 
 .card {
-    background: #ffffff;
-    border: 1px solid var(--border);
-    border-radius: 1rem;
-    padding: 1rem;
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 1.1rem;
+    padding: clamp(.85rem, 2.5vw, 1.25rem);
+    box-shadow: 0 14px 32px rgba(78, 41, 27, .12);
 }
 
 .muted {
@@ -118,19 +171,19 @@ a:hover {
 }
 
 .bg-green-50 {
-    background: #ecfdf5;
+    background: #e9f7ef;
 }
 
 .border-green-300 {
-    border-color: #86efac;
+    border-color: #bfe6ca;
 }
 
 .bg-red-50 {
-    background: #fef2f2;
+    background: #fcecec;
 }
 
 .border-red-300 {
-    border-color: #fca5a5;
+    border-color: #f3b9b9;
 }
 
 .text-sm {
@@ -138,7 +191,7 @@ a:hover {
 }
 
 .text-gray-500 {
-    color: #6b7280;
+    color: var(--muted);
 }
 
 .mt-8 {
@@ -159,16 +212,19 @@ a:hover {
     height: 40px;
     border-radius: 999px;
     object-fit: cover;
+    border: 1px solid var(--line);
+    background: #fff;
 }
 
-.grid-2 {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 1rem;
+input,
+textarea,
+select {
+    font: inherit;
 }
 
-@media (min-width: 900px) {
-    .grid-2 {
-        grid-template-columns: 2fr 1fr;
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation: none !important;
+        transition: none !important;
     }
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,7 +21,9 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;600;700&family=Righteous&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;600;700&family=Unna:wght@400;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="{{ asset('css/base.css') }}">
 
     @if ($hasViteBuild)
         {{-- Usa assets generados por Vite si existen --}}
@@ -35,115 +37,127 @@
     @stack('head')
 
     <style>
-        :root {
-            --muted: #4c566a;
-            --maroon: #b3472d;
-            --border: #d8dee9;
-            --night: #1f2937;
-            --amber: #fbbf24;
-            --emerald: #34d399;
-        }
-
-        .muted {
-            color: var(--muted)
-        }
-
-        .pill {
-            display: inline-block;
-            border: 1px solid var(--border);
-            border-radius: 999px;
-            padding: .125rem .5rem;
-            font-size: .75rem
-        }
-
         body {
             font-family: 'Nunito Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-            background:
-                radial-gradient(circle at 0% 0%, rgba(255, 255, 255, 0.25) 0, rgba(255, 255, 255, 0) 60%),
-                radial-gradient(circle at 100% 0%, rgba(255, 255, 255, 0.25) 0, rgba(255, 255, 255, 0) 60%),
-                linear-gradient(135deg, #0f172a 0%, #1e293b 35%, #273549 70%, #2f3f57 100%);
-            color: #1f2937;
+            background: var(--bg);
+            background-image:
+                radial-gradient(circle at 0% 0%, rgba(255, 255, 255, .6), rgba(255, 255, 255, 0) 55%),
+                radial-gradient(circle at 100% 0%, rgba(255, 255, 255, .45), rgba(255, 255, 255, 0) 45%),
+                linear-gradient(180deg, rgba(255, 247, 238, .35), rgba(255, 247, 238, 0));
+            color: var(--ink);
             min-height: 100vh;
         }
 
+        .page-body {
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        h1,
+        h2,
+        h3,
         .app-title {
-            font-family: 'Righteous', cursive;
-            letter-spacing: .02em;
+            font-family: 'Unna', 'Times New Roman', serif;
+            color: var(--maroon);
+            letter-spacing: .04em;
         }
 
         .container {
             max-width: 1100px;
             margin: 0 auto;
-            padding: 1.25rem;
+            padding: clamp(.9rem, 3vw, 1.4rem);
         }
 
-        .btn {
+        .site-header {
+            position: sticky;
+            top: 0;
+            z-index: 20;
+            background: linear-gradient(135deg, var(--maroon), var(--maroon-press));
+            color: #fff;
+            box-shadow: 0 14px 32px rgba(123, 30, 30, .28);
+        }
+
+        .site-header .container {
+            display: flex;
+            align-items: center;
+            gap: clamp(.75rem, 3vw, 1.5rem);
+        }
+
+        .brand {
             display: inline-flex;
             align-items: center;
-            gap: .5rem;
-            border-radius: 999px;
-            padding: .55rem 1.1rem;
-            font-weight: 600;
-            letter-spacing: .01em;
-            background: linear-gradient(135deg, rgba(255,255,255,.12), rgba(255,255,255,0));
-            color: #fff;
-            border: 1px solid rgba(255, 255, 255, 0.25);
-            box-shadow: 0 6px 18px rgba(15, 23, 42, 0.25);
-            transition: transform .2s ease, box-shadow .2s ease, background .2s ease;
+            gap: .75rem;
+            color: inherit;
             text-decoration: none;
+            font-weight: 700;
         }
 
-        .btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 10px 20px rgba(15, 23, 42, 0.3);
-            background: linear-gradient(135deg, rgba(255,255,255,.24), rgba(255,255,255,0.05));
+        .brand-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 46px;
+            height: 46px;
+            border-radius: 14px;
+            background: radial-gradient(circle at 30% 30%, #fff5d6, #f1c56d 65%, #cf9f41 100%);
+            color: var(--maroon);
+            box-shadow: 0 10px 22px rgba(0, 0, 0, .22);
+            font-size: 1.55rem;
         }
 
-        .btn.gold {
-            background: linear-gradient(135deg, #fbbf24, #f97316);
-            border-color: rgba(251, 191, 36, .8);
-            color: #1f2937;
-            box-shadow: 0 8px 18px rgba(251, 191, 36, 0.35);
+        .app-title {
+            font-size: clamp(1.4rem, 3vw, 1.7rem);
+            color: #fff7ee;
+            text-transform: uppercase;
         }
 
-        .btn.gold:hover {
-            background: linear-gradient(135deg, #facc15, #fb923c);
+        .main-nav {
+            display: flex;
+            align-items: center;
+            gap: .6rem;
+            flex-wrap: wrap;
+            margin-left: auto;
         }
 
-        .btn.red {
-            background: linear-gradient(135deg, #f87171, #ef4444);
-            border-color: rgba(239, 68, 68, .85);
-            box-shadow: 0 8px 18px rgba(248, 113, 113, 0.35);
-            color: #fff;
+        .site-header .btn {
+            background: rgba(255, 255, 255, .12);
+            border-color: rgba(255, 255, 255, .3);
+            color: #fff7ee;
+            font-weight: 600;
+            transition: background .2s ease, transform .2s ease;
         }
 
-        .btn.green {
-            background: linear-gradient(135deg, #34d399, #059669);
-            border-color: rgba(5, 150, 105, .75);
-            box-shadow: 0 8px 18px rgba(52, 211, 153, 0.35);
-            color: #032b1f;
+        .site-header .btn:hover {
+            background: rgba(255, 255, 255, .22);
+            transform: translateY(-1px);
         }
 
-        .card {
-            background: linear-gradient(145deg, rgba(255,255,255,.95), rgba(255,255,255,.85));
-            border: 1px solid rgba(255, 255, 255, 0.35);
-            border-radius: 1.25rem;
-            padding: 1.25rem;
-            box-shadow: 0 18px 35px rgba(15, 23, 42, 0.22);
-            backdrop-filter: blur(6px);
+        .site-header .btn.gold {
+            background: linear-gradient(135deg, var(--gold), var(--gold-press));
+            border-color: transparent;
+            color: var(--ink);
+            box-shadow: 0 10px 22px rgba(200, 162, 76, .36);
         }
 
-        .avatar {
-            width: 40px;
-            height: 40px;
-            border-radius: 999px;
-            object-fit: cover
+        .site-header .btn.gold:hover {
+            transform: translateY(-1px) scale(1.01);
+        }
+
+        .site-main {
+            flex: 1;
+            padding: clamp(1.8rem, 5vw, 3rem) 0 clamp(2.8rem, 6vw, 4rem);
+        }
+
+        .site-main .container {
+            display: grid;
+            gap: clamp(1rem, 3vw, 1.6rem);
         }
 
         .grid-2 {
             display: grid;
             grid-template-columns: 1fr;
-            gap: 1rem
+            gap: clamp(1.2rem, 4vw, 1.8rem);
         }
 
         @media (min-width: 900px) {
@@ -151,48 +165,93 @@
                 grid-template-columns: 2fr 1fr;
             }
         }
+
+        .flash {
+            padding: .85rem 1rem;
+            border-radius: 1rem;
+            border: 1px solid var(--line);
+            background: var(--card, var(--paper));
+            box-shadow: 0 12px 28px rgba(78, 41, 27, .12);
+            font-weight: 600;
+        }
+
+        .flash-ok {
+            background: #e9f7ef;
+            border-color: #bfe6ca;
+            color: #165534;
+        }
+
+        .flash-err {
+            background: #fcecec;
+            border-color: #f3b9b9;
+            color: var(--maroon);
+        }
+
+        .site-footer {
+            background: linear-gradient(135deg, var(--maroon), var(--maroon-press));
+            color: #f8ede0;
+            text-align: center;
+            padding: 1.75rem 1rem;
+            border-top: 1px solid rgba(0, 0, 0, .08);
+            font-size: .95rem;
+            letter-spacing: .03em;
+        }
+
+        .site-footer a {
+            color: inherit;
+            text-decoration: underline;
+        }
+
+        @media (max-width: 640px) {
+            .site-header .container {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .main-nav {
+                width: 100%;
+            }
+        }
     </style>
 </head>
 
-<body class="bg-gray-50 text-gray-900">
-    <header class="border-b" style="border-color: rgba(255,255,255,.08); background: linear-gradient(135deg, rgba(15,23,42,.85), rgba(30,41,59,.85)); backdrop-filter: blur(10px); position: sticky; top: 0; z-index: 20;">
-        <div class="container flex items-center justify-between" style="gap: 1.5rem;">
-            <a href="{{ route('home') }}"
-               class="font-bold text-lg app-title text-white flex items-center gap-2">
-                <span style="display:inline-flex;align-items:center;justify-content:center;width:40px;height:40px;border-radius:12px;background:linear-gradient(135deg,#fbbf24,#f97316);color:#111827;box-shadow:0 8px 18px rgba(251,191,36,.35);">🎲</span>
-                {{ config('app.name', 'La Taberna') }}
+<body class="page-body">
+    <header class="site-header" role="banner">
+        <div class="container">
+            <a href="{{ route('home') }}" class="brand">
+                <span class="brand-badge">🍷</span>
+                <span class="app-title">{{ config('app.name', 'La Taberna') }}</span>
             </a>
-            <nav class="flex items-center gap-2">
-                <a class="btn"
-                   href="{{ route('mesas.index') }}">Mesas</a>
+            <nav class="main-nav" aria-label="{{ __('Principal') }}">
+                <a class="btn" href="{{ route('mesas.index') }}">Mesas</a>
 
                 @can('manage-tables')
                     @if(\Illuminate\Support\Facades\Route::has('mesas.create'))
-                        <a class="btn gold"
-                           href="{{ route('mesas.create') }}">➕ Nueva mesa</a>
+                        <a class="btn gold" href="{{ route('mesas.create') }}">➕ Nueva mesa</a>
                     @endif
                 @endcan
 
                 @auth
-                    <a class="btn"
-                       href="{{ route('dashboard') }}">Panel</a>
+                    <a class="btn" href="{{ route('dashboard') }}">Panel</a>
                 @endauth
             </nav>
         </div>
     </header>
 
-    <main class="container" style="padding-top: 2.5rem; padding-bottom: 3rem;">
-        @if (session('ok'))
-            <div class="card mb-3 bg-green-50 border-green-300">{{ session('ok') }}</div>
-        @endif
-        @if (session('err'))
-            <div class="card mb-3 bg-red-50 border-red-300">{{ session('err') }}</div>
-        @endif
+    <main class="site-main">
+        <div class="container">
+            @if (session('ok'))
+                <div class="flash flash-ok" role="status">{{ session('ok') }}</div>
+            @endif
+            @if (session('err'))
+                <div class="flash flash-err" role="alert">{{ session('err') }}</div>
+            @endif
 
-        @yield('content')
+            @yield('content')
+        </div>
     </main>
 
-    <footer class="mt-8 py-6 text-center text-sm text-gray-200" style="border-top: 1px solid rgba(255,255,255,.1); background: linear-gradient(135deg, rgba(15,23,42,.85), rgba(30,41,59,.85));">
+    <footer class="site-footer">
         © {{ date('Y') }} {{ config('app.name', 'La Taberna') }} · Comunidad de Juegos de Mesa
     </footer>
 


### PR DESCRIPTION
## Summary
- align the public fallback stylesheet with a warm tavern-inspired palette and refreshed button treatments
- restyle the main application layout with new typography, header, and flash messaging that match the updated theme

## Testing
- composer install *(fails: requires GitHub token to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e55d1b2eb4832c96810a32070f2eed